### PR TITLE
Fixed a bug with custom function arguments.

### DIFF
--- a/opencart.php
+++ b/opencart.php
@@ -103,7 +103,8 @@ class Base {
         return $voidProp;
     }
 
-    public function __call($name, $postData) {
+    public function __call($name, $args) {
+	$postData = $args[0];
         $dynamicRoute = $this->dynamicRoute;
         $dynamicRoute[] = $name;
         $route = implode('/', $dynamicRoute);


### PR DESCRIPTION
$postData was taking the whole args list from the __call() function. Changed $postData to take only the first argument ($args[0]).